### PR TITLE
Added alternate_xmlns_url variable for sparkle

### DIFF
--- a/Volitans Software/SMART Utility.download.recipe
+++ b/Volitans Software/SMART Utility.download.recipe
@@ -24,6 +24,8 @@
 			<dict>
 				<key>appcast_url</key>
 				<string>%SPARKLE_FEED_URL%</string>
+				<key>alternate_xmlns_url</key>
+        			<string>https://www.andymatuschak.org/xml-namespaces/sparkle</string>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
The xmlns in the SMART Utility feed is different than the default xmlns in the SparkleUpdateInfoProvider processor.  The feed uses `https` where the default is `http`.  

SMART Utility feed:

```
curl https://www.volitans-software.com/appcasts/su-appcast.xml
<?xml version="1.0" encoding="utf-8"?>
<rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="https://purl.org/dc/elements/1.1/">
```

SparkleInfoUpdateProvider code https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/SparkleUpdateInfoProvider.py#L31

```
DEFAULT_XMLNS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
```
