### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/BitControl Networks GmbH/CocoaPacketAnalyzer.download.recipe
+++ b/BitControl Networks GmbH/CocoaPacketAnalyzer.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/CocoaPacketAnalyzer.app</string>
 				<key>requirement</key>
 				<string>identifier "com.tastycocoabytes.CocoaPacketAnalyzer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6QDCK94P7Y"</string>
 			</dict>

--- a/Volitans Software/SMART Utility.download.recipe
+++ b/Volitans Software/SMART Utility.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%/SMART Utility.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.volitans-software.smartutility" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YJ65CCRY6B)</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.