### PR TITLE
Pre-commit configuration for AutoPkg recipes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 - repo: https://github.com/homebysix/pre-commit-macadmin
-  rev: v1.5.1
+  rev: v1.8.1
   hooks:
   - id: check-autopkg-recipes
-    args: ['--recipe-prefix', 'com.github.flammable.', '--strict']
+    args: ['--recipe-prefix', 'com.github.flammable.', '--strict', '--']
   - id: forbid-autopkg-overrides
   - id: forbid-autopkg-trust-info
   - id: check-plists
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v3.3.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=100']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+- repo: https://github.com/homebysix/pre-commit-macadmin
+  rev: v1.5.1
+  hooks:
+  - id: check-autopkg-recipes
+    args: ['--recipe-prefix', 'com.github.flammable.', '--strict']
+  - id: forbid-autopkg-overrides
+  - id: forbid-autopkg-trust-info
+  - id: check-plists
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: check-added-large-files
+    args: ['--maxkb=100']
+  - id: check-byte-order-marker
+  - id: check-case-conflict
+  - id: check-merge-conflict
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: trailing-whitespace


### PR DESCRIPTION
For your consideration, this pull request adds a [pre-commit](https://pre-commit.com) configuration that will automatically test your recipes for common issues and misconfigurations before each commit.

To start using, you'll need pre-commit [installed](https://pre-commit.com/#install) on the Mac you develop recipes on. You'll also need to `cd` to your local recipe repository and run `pre-commit install` once to activate the hooks. After that, just use `git commit` as you usually would.

I've made sure that all your recipes pass the pre-commit tests in their current form:

```
$ pre-commit run --all-files 
Check AutoPkg Recipes....................................................Passed
Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
Check Plists.............................................................Passed
Check for added large files..............................................Passed
Check for byte-order marker..............................................Passed
Check for case conflicts.................................................Passed
Check for merge conflicts................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
```

If you accept this change, I'd love to hear your feedback on my AutoPkg-specific pre-commit hooks. I'm still actively developing them and tweaking features, so please let me know if you have any questions or find problems.

Thanks for considering!