### PR TITLE
Update dupeGuru.download.recipe

### DIFF
--- a/dupeGuru/dupeGuru.download.recipe
+++ b/dupeGuru/dupeGuru.download.recipe
@@ -24,8 +24,6 @@
 					<string>(?P&lt;url&gt;https:\/\/github\.com\/arsenetar\/dupeguru\/releases\/download\/.*\/dupeguru_osx_.*\.dmg)</string>
 					<key>url</key>
 					<string>https://dupeguru.voltaicideas.net</string>
-					<key>user-agent</key>
-					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36</string>
 				</dict>
 				<key>Processor</key>
 				<string>URLTextSearcher</string>

--- a/dupeGuru/dupeGuru.download.recipe
+++ b/dupeGuru/dupeGuru.download.recipe
@@ -1,46 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of dupeGuru.</string>
-	<key>Identifier</key>
-	<string>com.github.flammable.download.dupeGuru</string>
-	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>dupeGuru</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://www.hardcoded.net/updates/dupeguru.appcast</string>
+		<key>Description</key>
+		<string>Downloads the current version of dupeGuru.</string>
+		<key>Identifier</key>
+		<string>com.github.grahampugh.recipes.download.dupeGuru</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>dupeGuru</string>
+			<key>STOPPROCESSINGIF_PREDICATE</key>
+			<string>download_changed == FALSE</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>2.0</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>re_pattern</key>
+					<string>(?P&lt;url&gt;https:\/\/github\.com\/arsenetar\/dupeguru\/releases\/download\/.*\/dupeguru_osx_.*\.dmg)</string>
+					<key>url</key>
+					<string>https://dupeguru.voltaicideas.net</string>
+					<key>user-agent</key>
+					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLTextSearcher</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>url</key>
+					<string>%url%</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+		</array>
 	</dict>
-	<key>MinimumVersion</key>
-	<string>0.5.0</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-	</array>
-</dict>
 </plist>

--- a/dupeGuru/dupeGuru.download.recipe
+++ b/dupeGuru/dupeGuru.download.recipe
@@ -5,7 +5,7 @@
 		<key>Description</key>
 		<string>Downloads the current version of dupeGuru.</string>
 		<key>Identifier</key>
-		<string>com.github.grahampugh.recipes.download.dupeGuru</string>
+		<string>com.github.flammable.download.dupeGuru</string>
 		<key>Input</key>
 		<dict>
 			<key>NAME</key>


### PR DESCRIPTION
Ownership of dupeGuru has changed, and the Sparkle Feed no longer exists. It's easy enough to scrape the new webpage https://dupeguru.voltaicideas.net. One could possibly also use GitHubReleaseProvider, but since the macOS version is behind the latest, that might be frail.

The app is not signed, so no point in `CodeSignatureVerifier`. Hence: omitted.