### PR TITLE
Remove NAME reference to expanded SMART Utility folder contents

### DIFF
--- a/Volitans Software/SMART Utility.download.recipe
+++ b/Volitans Software/SMART Utility.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%/SMART Utility.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SMART Utility/SMART Utility.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.volitans-software.smartutility" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YJ65CCRY6B)</string>
 			</dict>

--- a/Volitans Software/SMART Utility.munki.recipe
+++ b/Volitans Software/SMART Utility.munki.recipe
@@ -44,7 +44,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SMART Utility</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>


### PR DESCRIPTION
The contents of the SMART Utility zip are not linked to the NAME input variable, so should be hard-coded in the CodeSignatureVerifier and DmgCreator file paths.

Verbose download/munki recipe run output:

```
% autopkg run -vvq SMART\ Utility.*.recipe
Processing SMART Utility.download.recipe...
WARNING: SMART Utility.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'alternate_xmlns_url': 'https://www.andymatuschak.org/xml-namespaces/sparkle',
           'appcast_url': 'https://www.volitans-software.com/stats/smart-utility/profileInfo.php'}}
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 3C142
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.2.7
SparkleUpdateInfoProvider: Found URL https://cloudfront.volitans-software.com/smartutility327.zip
{'Output': {'url': 'https://cloudfront.volitans-software.com/smartutility327.zip',
            'version': '3.2.7'}}
URLDownloader
{'Input': {'filename': 'SMART Utility-3.2.7.zip',
           'url': 'https://cloudfront.volitans-software.com/smartutility327.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 29 Apr 2022 15:30:16 GMT
URLDownloader: Storing new ETag header: "83e667cc296e5c0a7866b51b1f9ab1c0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/downloads/SMART Utility-3.2.7.zip
{'Output': {'download_changed': True,
            'etag': '"83e667cc296e5c0a7866b51b1f9ab1c0"',
            'last_modified': 'Fri, 29 Apr 2022 15:30:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/downloads/SMART '
                        'Utility-3.2.7.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/downloads/SMART '
                                                                        'Utility-3.2.7.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/downloads/SMART '
                           'Utility-3.2.7.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/SMART '
                               'Utility/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename SMART Utility-3.2.7.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/downloads/SMART Utility-3.2.7.zip to ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/SMART Utility/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/SMART '
                         'Utility/Applications/SMART Utility/SMART Utility.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.volitans-software.smartutility" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'YJ65CCRY6B)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/SMART Utility/Applications/SMART Utility/SMART Utility.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/SMART Utility/Applications/SMART Utility/SMART Utility.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/SMART Utility/Applications/SMART Utility/SMART Utility.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/receipts/SMART Utility.download-receipt-20241227-183344.plist
Processing SMART Utility.munki.recipe...
WARNING: SMART Utility.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'alternate_xmlns_url': 'https://www.andymatuschak.org/xml-namespaces/sparkle',
           'appcast_url': 'https://www.volitans-software.com/stats/smart-utility/profileInfo.php'}}
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 3C142
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.2.7
SparkleUpdateInfoProvider: Found URL https://cloudfront.volitans-software.com/smartutility327.zip
{'Output': {'url': 'https://cloudfront.volitans-software.com/smartutility327.zip',
            'version': '3.2.7'}}
URLDownloader
{'Input': {'filename': 'SMART Utility-3.2.7.zip',
           'url': 'https://cloudfront.volitans-software.com/smartutility327.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 29 Apr 2022 15:30:16 GMT
URLDownloader: Storing new ETag header: "83e667cc296e5c0a7866b51b1f9ab1c0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/downloads/SMART Utility-3.2.7.zip
{'Output': {'download_changed': True,
            'etag': '"83e667cc296e5c0a7866b51b1f9ab1c0"',
            'last_modified': 'Fri, 29 Apr 2022 15:30:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/downloads/SMART '
                        'Utility-3.2.7.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/downloads/SMART '
                                                                        'Utility-3.2.7.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/downloads/SMART '
                           'Utility-3.2.7.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART '
                               'Utility/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename SMART Utility-3.2.7.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/downloads/SMART Utility-3.2.7.zip to ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART Utility/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART '
                         'Utility/Applications/SMART Utility/SMART Utility.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.volitans-software.smartutility" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'YJ65CCRY6B)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART Utility/Applications/SMART Utility/SMART Utility.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART Utility/Applications/SMART Utility/SMART Utility.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART Utility/Applications/SMART Utility/SMART Utility.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART '
                       'Utility.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART '
                       'Utility/Applications/SMART Utility'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART Utility/Applications/SMART Utility at ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART Utility.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/SMART '
                       'Utility.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Checks the hardware diagnostics system '
                                      'of hard drives.',
                       'developer': 'Volitans Software',
                       'display_name': 'SMART Utility',
                       'name': 'SMART Utility',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/SMART Utility'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SMART Utility/SMART Utility-3.2.7__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/SMART Utility/SMART Utility-3.2.7__2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'SMART Utility',
                                                       'pkg_repo_path': 'apps/SMART '
                                                                        'Utility/SMART '
                                                                        'Utility-3.2.7__2.dmg',
                                                       'pkginfo_path': 'apps/SMART '
                                                                       'Utility/SMART '
                                                                       'Utility-3.2.7__2.plist',
                                                       'version': '3.2.7'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 28, 2, 33, 57),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Checks the hardware diagnostics '
                                          'system of hard drives.',
                           'developer': 'Volitans Software',
                           'display_name': 'SMART Utility',
                           'installer_item_hash': '90b0bcd554669b09b3bb985c16e87ead1ecbe0ac5dce40c13d9c27a1f1b3614d',
                           'installer_item_location': 'apps/SMART '
                                                      'Utility/SMART '
                                                      'Utility-3.2.7__2.dmg',
                           'installer_item_size': 7437,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.volitans-software.smartutility',
                                         'CFBundleName': 'SMART Utility',
                                         'CFBundleShortVersionString': '3.2.7',
                                         'CFBundleVersion': '3C142',
                                         'minosversion': '10.9',
                                         'path': '/Applications/SMART '
                                                 'Utility.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'SMART '
                                                             'Utility.app'}],
                           'minimum_os_version': '10.9',
                           'name': 'SMART Utility',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.2.7'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/SMART '
                             'Utility/SMART Utility-3.2.7__2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/SMART '
                                 'Utility/SMART Utility-3.2.7__2.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/receipts/SMART Utility.munki-receipt-20241227-183357.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    ~/Library/AutoPkg/Cache/com.github.flammable.download.SMARTUtility/downloads/SMART Utility-3.2.7.zip  
    ~/Library/AutoPkg/Cache/com.github.flammable.munki.SMARTUtility/downloads/SMART Utility-3.2.7.zip     

The following new items were imported into Munki:
    Name           Version  Catalogs  Pkginfo Path                                     Pkg Repo Path                                  Icon Repo Path  
    ----           -------  --------  ------------                                     -------------                                  --------------  
    SMART Utility  3.2.7    testing   apps/SMART Utility/SMART Utility-3.2.7__2.plist  apps/SMART Utility/SMART Utility-3.2.7__2.dmg
```