### PR TITLE
Deprecate Veertu Desktop recipes

### DIFF
--- a/Veertu Inc/Veertu Desktop.download.recipe
+++ b/Veertu Inc/Veertu Desktop.download.recipe
@@ -16,9 +16,18 @@
 		<string>https://d2sje6b9huarvp.cloudfront.net/vdoaupd.rss</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Veertu Desktop is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the non-functional Veertu Desktop recipes. This product appears to no longer be available for download.
