### PR TITLE
Remove version-specific Whisky download URL

### DIFF
--- a/Isaac Marovitz/Whisky.download.recipe
+++ b/Isaac Marovitz/Whisky.download.recipe
@@ -30,9 +30,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
-				<key>url</key>
-				<string>https://data.getwhisky.app/Releases/v2.3.2/Whisky.zip</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The current Whisky recipes have a hard-coded download URL, which is contrary to the purpose of AutoPkg. This PR allows SparkleUpdateInfoProvider to provide the download URL for each new version of Whisky.

Verbose recipe run output:

```
% autopkg run -vvq 'Isaac Marovitz/Whisky.download.recipe'
Processing Isaac Marovitz/Whisky.download.recipe...
WARNING: Isaac Marovitz/Whisky.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://data.getwhisky.app/appcast.xml'}}
SparkleUpdateInfoProvider: Items in feed: 3
SparkleUpdateInfoProvider: Items in default channel: 3
SparkleUpdateInfoProvider: Version retrieved from appcast: 42
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.3.4
SparkleUpdateInfoProvider: Found URL https://data.getwhisky.app/Releases/v2.3.4/Whisky.zip
{'Output': {'url': 'https://data.getwhisky.app/Releases/v2.3.4/Whisky.zip',
            'version': '2.3.4'}}
URLDownloader
{'Input': {'filename': 'Whisky-2.3.4.zip',
           'url': 'https://data.getwhisky.app/Releases/v2.3.4/Whisky.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 10 Nov 2024 00:13:09 GMT
URLDownloader: Storing new ETag header: "131f4846a2cf1427a4845a625abd7f98"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/downloads/Whisky-2.3.4.zip
{'Output': {'download_changed': True,
            'etag': '"131f4846a2cf1427a4845a625abd7f98"',
            'last_modified': 'Sun, 10 Nov 2024 00:13:09 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/downloads/Whisky-2.3.4.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/downloads/Whisky-2.3.4.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/downloads/Whisky-2.3.4.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Whisky-2.3.4.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/downloads/Whisky-2.3.4.zip to ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky/Whisky.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.isaacmarovitz.Whisky" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "92S3SG4PTH")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky/Whisky.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky/Whisky.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky/Whisky.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky/Whisky.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 2.3.4 in file ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/Whisky/Whisky.app/Contents/Info.plist
{'Output': {'version': '2.3.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/receipts/Whisky.download-receipt-20241228-124740.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.flammable.download.Whisky/downloads/Whisky-2.3.4.zip
```
