### PR TITLE
Deprecate Sequel Ace recipes

### DIFF
--- a/Sequel Ace/Sequel Ace.download.recipe
+++ b/Sequel Ace/Sequel Ace.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Sequel Ace recipes in the gerardkok-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>


### PR DESCRIPTION
The Sequel Ace download and munki recipes in this repo are similar in function to the earlier-created ones in gerardkok-recipes. This PR deprecates the ones in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!