### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Prefs Editor/Prefs Editor.download.recipe
+++ b/Prefs Editor/Prefs Editor.download.recipe
@@ -23,7 +23,7 @@
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>http://files.tempel.org/Various/OSX_Prefs_Editor/PrefsEditor.zip</string>
+				<string>https://files.tempel.org/Various/OSX_Prefs_Editor/PrefsEditor.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._